### PR TITLE
Explicitly pass --rsync-mode cli argument

### DIFF
--- a/roles/ocluster/templates/com.tarides.ocluster.worker.plist
+++ b/roles/ocluster/templates/com.tarides.ocluster.worker.plist
@@ -38,6 +38,7 @@
                 <string>--fuse-path={{ homebrew_prefix }}</string>
                 <string>--scoreboard=/Users/administrator/scoreboard</string>
                 <string>--obuilder-store=rsync:/Volumes/rsync</string>
+		<string>--rsync-mode=hardlink</string>
                 <string>--state-dir=/var/lib/ocluster-worker</string>
                 <string>--name={{ inventory_hostname_short }}</string>
                 <string>--capacity=1</string>


### PR DESCRIPTION
Additional --rsync-mode argument required for https://github.com/ocurrent/ocluster/pull/202

Currently we are running with hardlink_unsafe which is faster but unsafe as it doesn't perform checksums. 
This change will still use hard links but will perform checksumming.