### PR TITLE
Latest updates to Ansible scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,12 @@ sudo umount /usr/local
 launchctl load Library/LaunchAgents/com.tarides.ocluster.worker.plist
 ```
 
-Check the playbook `flush-rsync.yml` which automatically performs these steps:
+Check the playbook `flush-rsync.yml` which automatically performs these steps including:
+* Pausing the worker in the pool
+* Unloading the worker service
+* Update the OCluster code from GitHub
+* Loading the worker service
+* Unpausing the worker in the pool
 
 ```
 ansible-playbook -i hosts --limit i7-worker-04.macos.ci.dev flush-rsync.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
 allow_world_readable_tmpfiles=true
+ansible_python_interpreter=/usr/bin/python3

--- a/flush-rsync.yml
+++ b/flush-rsync.yml
@@ -41,6 +41,16 @@
       state: absent
       path: "{{ ansible_env.HOME }}/ocluster.log"
 
+  - name: Remove ocluster
+    file:
+      state: absent
+      path: "{{ ansible_env.HOME }}/ocluster"
+
+  - name: Remove opam
+    file:
+      state: absent
+      path: "{{ ansible_env.HOME }}/.opam"
+
   - name: Create empty folder
     file:
       state: directory
@@ -50,14 +60,39 @@
     shell: rsync -aHq --delete /tmp/obuilder-empty/ /Volumes/rsync/
     become: yes
 
+  - name: Install Opam
+    import_role:
+      name: ocaml
+    environment:
+      PATH: '{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+
+#  - name: Create base image 4.14.0
+#    import_role:
+#      name: base-image
+#    vars:
+#      version: "4.14.0"
+#      user_name: "mac1000"
+#    environment:
+#      PATH: '{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+
+#  - name: Create base image 5.0.0
+#    import_role:
+#      name: base-image
+#    vars:
+#      version: "5.0.0"
+#      user_name: "mac1000"
+#    environment:
+#      PATH: '{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+
   - name: Update OCluster
     import_role:
       name: ocluster
     environment:
       PATH: '{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
 
-  - name: Start ocluster service
-    shell: launchctl load {{ ansible_env.HOME}}/Library/LaunchAgents/com.tarides.ocluster.worker.plist
+# the service is started above ocluster role
+#  - name: Start ocluster service
+#    shell: launchctl load {{ ansible_env.HOME}}/Library/LaunchAgents/com.tarides.ocluster.worker.plist
 
   - name: Unpause the worker
     shell: ci3-admin unpause macos-{{ ansible_architecture }} {{ inventory_hostname_short }}

--- a/flush-rsync.yml
+++ b/flush-rsync.yml
@@ -14,15 +14,15 @@
       var: homebrew_prefix
 
 - hosts: all
+  serial: 1
   tasks:
 
-#  - name: Pause the worker
-#    shell: ci3-admin pause --wait macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
-#    delegate_to: 127.0.0.1
+  - name: Pause the worker
+    shell: ci3-admin pause --wait macos-{{ ansible_architecture }} {{ inventory_hostname_short }}
+    delegate_to: 127.0.0.1
 
   - name: Stop the ocluster service
-    shell: launchctl unload Library/LaunchAgents/com.tarides.ocluster.worker.plist
-    become: yes
+    shell: launchctl unload {{ ansible_env.HOME}}/Library/LaunchAgents/com.tarides.ocluster.worker.plist
 
   - name: Unmount {{ homebrew_prefix }} if it is mounted
     become: yes
@@ -30,18 +30,34 @@
       path: "{{ homebrew_prefix }}"
       state: unmounted
 
+  - name: Remove state dir
+    become: yes
+    file:
+      state: absent
+      path: /var/lib/ocluster-worker
+
+  - name: Remove ocluster.log
+    file:
+      state: absent
+      path: "{{ ansible_env.HOME }}/ocluster.log"
+
   - name: Create empty folder
     file:
       state: directory
       path: /tmp/obuilder-empty 
 
-  - name: Use rsync to delete everything in result-tmp
-    shell: rsync -aHq --delete /tmp/obuilder-empty/ /Volumes/rsync/result-tmp/
+  - name: Use rsync to delete everything in /Volumes/rsync/
+    shell: rsync -aHq --delete /tmp/obuilder-empty/ /Volumes/rsync/
     become: yes
 
+  - name: Update OCluster
+    import_role:
+      name: ocluster
+    environment:
+      PATH: '{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
+
   - name: Start ocluster service
-    shell: launchctl load Library/LaunchAgents/com.tarides.ocluster.worker.plist
-    become: yes
+    shell: launchctl load {{ ansible_env.HOME}}/Library/LaunchAgents/com.tarides.ocluster.worker.plist
 
   - name: Unpause the worker
     shell: ci3-admin unpause macos-{{ ansible_architecture }} {{ inventory_hostname_short }}

--- a/hosts
+++ b/hosts
@@ -6,3 +6,6 @@ m1-worker-01.macos.ci.dev
 m1-worker-02.macos.ci.dev
 m1-worker-03.macos.ci.dev
 m1-worker-04.macos.ci.dev
+
+[all:vars]
+ansible_python_interpreter=/usr/bin/python3

--- a/playbook.yml
+++ b/playbook.yml
@@ -35,10 +35,10 @@
   roles:
     - homebrew
     - ocaml
-   # - { role: sysinstall, versions: "4.14.0,5.0.0~rc1" }
+   # - { role: sysinstall, versions: "4.14.0,5.0.0" }
     - obuilder-fs
     - { role: base-image, version: "4.14.0", user_name: mac1000 }
-    - { role: base-image, version: "5.0.0~rc1", user_name: mac1000 }
+    - { role: base-image, version: "5.0.0", user_name: mac1000 }
     - busybox
     - ocluster
   environment:

--- a/playbook.yml
+++ b/playbook.yml
@@ -35,10 +35,10 @@
   roles:
     - homebrew
     - ocaml
-   # - { role: sysinstall, versions: "4.14.0,5.0.0~beta2" }
+   # - { role: sysinstall, versions: "4.14.0,5.0.0~rc1" }
     - obuilder-fs
     - { role: base-image, version: "4.14.0", user_name: mac1000 }
-    - { role: base-image, version: "5.0.0~beta2", user_name: mac1000 }
+    - { role: base-image, version: "5.0.0~rc1", user_name: mac1000 }
     - busybox
     - ocluster
   environment:

--- a/playbook.yml
+++ b/playbook.yml
@@ -35,9 +35,9 @@
   roles:
     - homebrew
     - ocaml
-   # - { role: sysinstall, versions: "4.14.0,5.0.0" }
+   # - { role: sysinstall, versions: "4.14.1,5.0.0" }
     - obuilder-fs
-    - { role: base-image, version: "4.14.0", user_name: mac1000 }
+    - { role: base-image, version: "4.14.1", user_name: mac1000 }
     - { role: base-image, version: "5.0.0", user_name: mac1000 }
     - busybox
     - ocluster

--- a/roles/ocluster/tasks/main.yml
+++ b/roles/ocluster/tasks/main.yml
@@ -13,16 +13,26 @@
 - name: Stop ocluster via launchctl
   shell: launchctl unload ~/Library/LaunchAgents/com.tarides.ocluster.worker.plist
 
+- name: Remove ~/ocluster
+  file:
+    path: "{{ ansible_env.HOME }}/ocluster"
+    state: absent
+
 - name: Download the source from GitHub
   git:
     repo: https://github.com/ocurrent/ocluster.git
     dest: "{{ ansible_env.HOME }}/ocluster"
     force: yes
 
-- name: Checkout the correct SHA
-  shell: git fetch origin master && git checkout fcadac0bbd967495cb0ed17a6a2c722e333e4f3a --recurse-submodules
-  args: 
+- name: Switch to Tim's PR
+  shell: git fetch origin pull/202/head:test-branch && git checkout test-branch
+  args:
     chdir: "{{ ansible_env.HOME }}/ocluster"
+
+- name: Update Obuilder
+  shell: git fetch && git checkout master
+  args:
+    chdir: "{{ ansible_env.HOME }}/ocluster/obuilder"
 
 - name: Update Fetcher variable to User_temp
   replace:
@@ -31,7 +41,12 @@
     replace: 'module Fetcher = Obuilder.User_temp'
 
 - name: Install Opam dependencies
-  shell: eval $(opam env) && opam install . -y --confirm-level=unsafe-yes
+  shell: eval $(opam env) && opam update && opam install dune fmt prometheus-app extunix capnp-rpc-unix digestif psq ppx_expect dune-build-info alcotest-lwt sqlite3 sha current_web lwt-dllist current_git tar-unix current_github -y --confirm-level=unsafe-yes
+  args:
+    chdir: "{{ ansible_env.HOME }}/ocluster"
+
+- name: Dune build
+  shell: eval $(opam env) && dune build
   args:
     chdir: "{{ ansible_env.HOME }}/ocluster"
 

--- a/roles/ocluster/tasks/main.yml
+++ b/roles/ocluster/tasks/main.yml
@@ -24,8 +24,8 @@
     dest: "{{ ansible_env.HOME }}/ocluster"
     force: yes
 
-- name: Switch to Tim's PR
-  shell: git fetch origin pull/202/head:test-branch && git checkout test-branch
+- name: Checkout the correct SHA
+  shell: git fetch origin master && git checkout f2a94b163f763d57a4a63614a62b39c1020e53e7 --recurse-submodules
   args:
     chdir: "{{ ansible_env.HOME }}/ocluster"
 

--- a/roles/ocluster/templates/com.tarides.ocluster.worker.plist
+++ b/roles/ocluster/templates/com.tarides.ocluster.worker.plist
@@ -22,22 +22,14 @@
 	<key>ProgramArguments</key>
 	<array>
                 <string>sudo</string>
-                <string>opam</string>
-                <string>exec</string>
-                <string>--</string>
-                <string>dune</string>
-                <string>exec</string>
-                <string>--profile</string>
-                <string>release</string>
-                <string>--</string>
-                <string>ocluster-worker</string>
+                <string>./_build/install/default/bin/ocluster-worker</string>
                 <string>--connect</string>
                 <string>/Users/administrator/pool-macos-{{ ansible_architecture }}.cap</string>
                 <string>--uid=1000</string>
                 <string>--fallback=/Users/administrator/lib</string>
                 <string>--fuse-path={{ homebrew_prefix }}</string>
                 <string>--scoreboard=/Users/administrator/scoreboard</string>
-                <string>--obuilder-store=rsync:/Volumes/rsync</string>
+                <string>--store=rsync:/Volumes/rsync</string>
 		<string>--rsync-mode=hardlink</string>
                 <string>--state-dir=/var/lib/ocluster-worker</string>
                 <string>--name={{ inventory_hostname_short }}</string>


### PR DESCRIPTION
* Remove warning about Python version
* Updated README.md
* Updated `flush-rsync.yml` to make pause the worker and stop the service before updates and updated Cluster
* Update to service `.plist` which now runs the compiled binary rather than `opam exec -- dune exec --`
* Update to service as Builder parameters have been renamed: `--obuilder-store` has been renamed `--store`