### PR TITLE
Update README.md with clarifications.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The Ansible playbook can be used to deploy Mac workers.  The following pre-requi
 - Install Apple Developer Command line tools
 - Turn off SIP by entering Recovery Mode (Intel: Command-R; M1: hold power button) `csrutil disable`
 - Install [macFUSE](https://osxfuse.github.io) which requires approval via System Preferences and a reboot of the system.
+  Use `brew install --cask macfuse` which will require a homebrew install.
 - Install [Docker Desktop for Mac](https://docs.docker.com/desktop/mac/install/)
 - Set Docker to automatically start at sign in
 - Add your ssh key to the `~/.ssh/authorized_keys` and update your `~/.ssh/config` so that you can SSH to the mac without prompting for a username:


### PR DESCRIPTION
After setting up a mac-mini using the ansible scripts, I had to manually fix these steps:
 - sudo setup step failed, manually created `/private/etc/sudoers.d/admin` with the contents. Not sure why? @mtelvers 
 - Missing install of macfuse `brew install --cask macfuse`, it's implied in the Prerequistes steps but the link points to the wrong way to install it. Using the desktop app, you don't get the header files required to build obuilder-fs later on
 - The ocluster pool cap file was missing but I downloaded that separately.