### PR TITLE
Use Git from Developer tools

### DIFF
--- a/roles/base-image/tasks/main.yml
+++ b/roles/base-image/tasks/main.yml
@@ -127,10 +127,6 @@
       /usr/libexec/path_helper
       export homebrew=$(brew --prefix)
 
-      # Git included in Apple Developer Tools is version 2.37.1
-      # Brew has version 2.38.1
-      brew install git
-
       # Opam requires GNU Patch
       brew install gpatch
       for i in $homebrew/Cellar/*/*/bin; do echo 'export PATH="'$i':$PATH' >> ~/.obuilder_profile.sh ; done


### PR DESCRIPTION
Due to the issues installing `git` via Homebrew (see https://github.com/ocaml/infrastructure/issues/132), reverting to `git` installed by Apple's developer tools.  This is later than the version mentioned in the script comments.

```
% git --version
git version 2.39.3 (Apple Git-146)
```