### PR TITLE
Add monitor script

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -21,11 +21,12 @@
     - docker
     - zfs
     - ocaml
-    - { role: base-image, version: "4.14.1", user_name: mac1000, zfs_pool: "obuilder", default: false }
-    - { role: base-image, version: "5.1.1", user_name: mac1000, zfs_pool: "obuilder", default: true }
-    - { role: base-image, version: "5.2.0+trunk", user_name: mac1000, zfs_pool: "obuilder", default: false }
+    - { role: base-image, version: "4.14.2", user_name: mac1000, zfs_pool: "obuilder", default: false }
+    - { role: base-image, version: "5.1.1", user_name: mac1000, zfs_pool: "obuilder", default: false }
+    - { role: base-image, version: "5.2.0", user_name: mac1000, zfs_pool: "obuilder", default: true }
     - { role: busybox, user_name: mac1000, zfs_pool: "obuilder" }
     - ocluster
+    - monitor
   environment:
     PATH: '{{ ansible_env.HOME }}/zfs/bin:{{ homebrew_prefix }}/bin:{{ ansible_env.PATH }}'
 

--- a/roles/monitor/tasks/main.yml
+++ b/roles/monitor/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Create monitor script
+  template:
+    src: monitor.sh
+    dest: "{{ ansible_env.HOME }}/monitor.sh"
+    mode: '0755'
+
+- name: Create plist service file
+  template:
+    src: com.tarides.ocluster.monitor.plist
+    dest: "/Library/LaunchDaemons/com.tarides.ocluster.monitor.plist"
+    owner: root
+    group: wheel
+    mode: '0644'
+  become: yes
+
+- name: Stop ocluster via launchctl
+  shell: launchctl unload /Library/LaunchDaemons/com.tarides.ocluster.monitor.plist
+  become: yes
+  register: launchctl_check
+  failed_when: not ( launchctl_check.rc == 134 or launchctl_check.rc == 0 )
+
+- name: Start ocluster via launchctl
+  shell: launchctl load /Library/LaunchDaemons/com.tarides.ocluster.monitor.plist
+  become: yes
+

--- a/roles/monitor/templates/com.tarides.ocluster.monitor.plist
+++ b/roles/monitor/templates/com.tarides.ocluster.monitor.plist
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>KeepAlive</key>
+	<true/>
+	<key>Label</key>
+	<string>com.tarides.ocluster.monitor</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+                <key>PATH</key>
+                <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{ ansible_env.HOME }}/monitor.sh</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>StandardErrorPath</key>
+	<string>{{ ansible_env.HOME }}/monitor.log</string>
+	<key>StandardOutPath</key>
+	<string>{{ ansible_env.HOME }}/monitor.log</string>
+	<key>WorkingDirectory</key>
+	<string>{{ ansible_env.HOME }}</string>
+</dict>
+</plist>

--- a/roles/monitor/templates/monitor.sh
+++ b/roles/monitor/templates/monitor.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if test -f {{ ansible_env.HOME }}/ocluster.log ; then
+	kc=$(tail {{ ansible_env.HOME }}/ocluster.log | grep pkill | wc -l)
+	if [ $kc -eq 10 ] ; then
+		rm -f {{ ansible_env.HOME }}/ocluster.log
+		date
+		sync
+		sudo reboot
+	fi
+fi


### PR DESCRIPTION
From time to time, when a job is cancelled, `ocluster-worker` will be unable to terminate all the processes.  `ocluster-worker` uses `pkill -9` repeatedly but never succeeds.  The only recourse is to reboot the system to clear the defunct processes.  This PR adds a script which monitors the output log file and reboots the machine when this happens.  This is an unfortunate workaround.  As these workers only handle a single job at a time, and this happens when a job is cancelled, it's safe to assume that the machine isn't doing any actual work at this point.