### PR TITLE
Add process output to monitor script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,24 @@ Host mac-mon-*
 	User administrator
 ```
 
-Run the playbook as follows.  I have used `--limit` to target a single worker.
+Before running the playbook, you will need
+
+- the vault password, and
+- the secrets file.
+
+Ask consult the [ansible docs on creating encrypted files][ansible-docs] if new credentials are needed.
+
+[ansible-docs]: https://docs.ansible.com/ansible/latest/vault_guide/vault_encrypting_content.html#creating-encrypted-files
+
+Then
+
+- Save the password in `./secerts/pwd`.
+- Save the secrets file in `./secrets/secret-vars.yml`.
+
+Run the playbook as follows. (I have used `--limit` to target a single worker).
 
 ```sh=
-ansible-playbook -i hosts --limit i7-worker-01 playbook.yml
+ansible-playbook -e @./secrets/secret-vars.yml --vault-password-file ./secrets/pwd -i hosts --limit i7-worker-01 playbook.yml
 ```
 
 ## Starting and Stopping

--- a/roles/monitor/tasks/main.yml
+++ b/roles/monitor/tasks/main.yml
@@ -15,17 +15,12 @@
     mode: '0644'
   become: yes
 
-- name: Stop ocluster via launchctl
+- name: Stop monitor process via launchctl
   shell: launchctl unload /Library/LaunchDaemons/com.tarides.ocluster.monitor.plist
   become: yes
   register: launchctl_check
   failed_when: not ( launchctl_check.rc == 134 or launchctl_check.rc == 0 )
 
-- name: Start ocluster via launchctl
+- name: Start monitor process via launchctl
   shell: launchctl load /Library/LaunchDaemons/com.tarides.ocluster.monitor.plist
   become: yes
-
-- name: delete old log
-  file:
-    path: "{{ ansible_env.HOME }}/monitor.log"
-    state: absent

--- a/roles/monitor/templates/monitor.sh
+++ b/roles/monitor/templates/monitor.sh
@@ -4,6 +4,7 @@ if test -f {{ ansible_env.HOME }}/ocluster.log ; then
 	kc=$(tail {{ ansible_env.HOME }}/ocluster.log | grep pkill | wc -l)
 	if [ $kc -eq 10 ] ; then
 		mv -f {{ ansible_env.HOME }}/ocluster.log {{ ansible_env.HOME }}/ocluster.old
+		msg="Rebooting $(uname -n)\n$(ps -j -U 1000)"
 		sync
 		sudo reboot
 	fi

--- a/roles/monitor/templates/monitor.sh
+++ b/roles/monitor/templates/monitor.sh
@@ -5,6 +5,7 @@ if test -f {{ ansible_env.HOME }}/ocluster.log ; then
 	if [ $kc -eq 10 ] ; then
 		mv -f {{ ansible_env.HOME }}/ocluster.log {{ ansible_env.HOME }}/ocluster.old
 		msg="Rebooting $(uname -n)\n$(ps -j -U 1000)"
+		curl -H "Content-type: application/json" -d '{ "text": "'${msg}'"  }' -X POST {{ slack_hook_url }}
 		sync
 		sudo reboot
 	fi


### PR DESCRIPTION
Adds the running processes belonging to the user as a diagnostic to
notifications sent from the monitoring script. See
https://github.com/tarides/infrastructure/issues/335#issuecomment-2231868184 for
context.

The monitor script needs a secret for sending notifications, see
73fbadea7f875dd9daadcbca2abdc99b778a225d for details.

This was written with @mtelvers and @punchagan during this week's infra
co-working session.