### PR TITLE
add include and libraries files path environment variables

### DIFF
--- a/roles/base-image/tasks/main.yml
+++ b/roles/base-image/tasks/main.yml
@@ -156,6 +156,10 @@
       echo 'export HOMEBREW_NO_AUTO_UPDATE=1' >> ~/.obuilder_profile.sh
       echo 'export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin' >> ~/.obuilder_profile.sh
       echo 'export PATH=/opt/homebrew/bin:/opt/homebrew/sbin:$PATH' >> ~/.obuilder_profile.sh # /opt is used for homebrew on macOS/arm64
+      # For arm64 architectures Homebrew no longer links into /usr/local by default.
+      # We add the include files and libraries paths to fix breakages for many packages in the ci that expect these files in /usr/local.
+      echo 'export C_INCLUDE_PATH=$homebrew/include:$C_INCLUDE_PATH' >> ~/.obuilder_profile.sh
+      echo 'export LIBRARY_PATH=$homebrew/lib:$LIBRARY_PATH' >> ~/.obuilder_profile.sh
       echo 'export OPAMYES=1' >> ./.obuilder_profile.sh
       echo 'export OPAMCONFIRMLEVEL=unsafe-yes' >> ./.obuilder_profile.sh
       echo 'export OPAMERRLOGLEN=0' >> ./.obuilder_profile.sh


### PR DESCRIPTION
on macos arm64 architectures, homebrew doesn't automatically link the include files and libraries automatically. Before it pointed to the installation path of `/usr/local`, but it doesn't [anymore](https://github.com/Homebrew/brew/pull/9117).

This creates a situation where building some packages fail on these architectures because the compiler can't find the expected include files. Eg ci build in [arm64](https://ocaml.ci.dev/github/ahrefs/monorobot/commit/edab7589b83fe5cce3011aeae192bd919757192c/variant/macos-homebrew-4.14_arm64_opam-2.3) vs [intel](https://ocaml.ci.dev/github/ahrefs/monorobot/commit/edab7589b83fe5cce3011aeae192bd919757192c/variant/macos-homebrew-4.14_opam-2.3).

I'm not sure this is the way maintainers expect to fix this situation, but I think this is a good place to do it. I imagine that trying to fix this inside the homebrew ecosystem would be a big task, and googling a bit, it seems that other programming languages ecosystems with the same issues didn't fix it at the homebrew level too.

This change was triggered by [ this comment](https://github.com/ocaml/opam-repository/pull/25759#issuecomment-2085864149), and by the personal experience of having to fix this on my machine too.

The downside I can see for this approach is that some packages might pass on ocaml CI, but then fail on the user's machines, but I think it's then up to them to look into how to fix it, or ask in discuss.ocaml.org 🤔 

Please advise, if this isn't the way to fix the situation, so that we can try to fix this, it would be good for quite some packages, i'd say.

Thank you